### PR TITLE
Helpscout 1918 homequery

### DIFF
--- a/wp-content/themes/invw/homepages/zones/invw-zones.php
+++ b/wp-content/themes/invw/homepages/zones/invw-zones.php
@@ -107,7 +107,7 @@ function zone_homepagegrid() {
 				'terms'    => 'homepage-featured'
 				),
 		),
-		'posts_per_page' => 5,
+		'posts_per_page' => 6,
 		'post__not_in' => $shown_ids,
 		'ignore_sticky_posts' => true
 	);
@@ -120,8 +120,8 @@ function zone_homepagegrid() {
 	 */
 	$grid_posts = array_slice($otherposts, 0, 2, true) +
 	array('member' => $members_post) +
-	array('redacted' => $redacted_post) +
-	array_slice($otherposts, 2, 3, true);
+	// array('redacted' => $redacted_post) +
+	array_slice($otherposts, 2, 4, true);
 	
 	$post_count = 0;
 

--- a/wp-content/themes/invw/homepages/zones/invw-zones.php
+++ b/wp-content/themes/invw/homepages/zones/invw-zones.php
@@ -78,10 +78,10 @@ function zone_homepagegrid() {
 	$redacted_id = 4541; // "Redacted" is a series
 	$members_id = 4514; // Members Exclusive series is known as "Sidebar" in the taxonomy
 
-	$redacted_post_query = largo_get_series_posts( $redacted_id, 1 );
-	$redacted_post = $redacted_post_query->posts[0];
-	$redacted_post->testing = 'redacted';
-	$shown_ids[] = $redacted_post->ID;
+	// $redacted_post_query = largo_get_series_posts( $redacted_id, 1 );
+	// $redacted_post = $redacted_post_query->posts[0];
+	// $redacted_post->testing = 'redacted';
+	// $shown_ids[] = $redacted_post->ID;
 	
 	$members_posts = new WP_Query(array(
 		'tax_query' => array(


### PR DESCRIPTION
Per https://secure.helpscout.net/conversation/567025814/1918?folderId=1847296 --

Currently the INVW homepage always displays a post from their "Redacted" series, even if it's quite old. In this pull request I commented out that specific query for the Redacted series; I also added one more spot to the regular recent posts query to ensure the grid is still completed.

A brand-new post in the Redacted series will still appear as a regular recent post, according to my local testing.